### PR TITLE
Fix ui-e2e CI: node:sqlite install + voiceflow-pro-ui build (green)

### DIFF
--- a/.github/workflows/ui-e2e.yml
+++ b/.github/workflows/ui-e2e.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
       - run: corepack enable
       - run: pnpm install --no-frozen-lockfile
       - run: npx audit-ci --high

--- a/voiceflow-pro-ui/package.json
+++ b/voiceflow-pro-ui/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "version": "1.0.0",
   "type": "module",
+  "packageManager": "pnpm@11.9.0",
   "scripts": {
     "dev": "pnpm install --prefer-offline && vite",
     "build": "pnpm install --prefer-offline && rm -rf node_modules/.vite-temp && tsc -b && vite build",

--- a/voiceflow-pro-ui/package.json
+++ b/voiceflow-pro-ui/package.json
@@ -73,6 +73,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.15.0",
+    "@playwright/test": "^1.61.1",
     "@types/node": "^22.10.7",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",

--- a/voiceflow-pro-ui/pnpm-workspace.yaml
+++ b/voiceflow-pro-ui/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+# esbuild (via vite) runs a build script. pnpm 11 blocks unapproved build scripts and
+# exits non-zero (ERR_PNPM_IGNORED_BUILDS); approving esbuild here lets `pnpm install`
+# succeed in CI without an interactive `pnpm approve-builds`.
+allowBuilds:
+  esbuild: true

--- a/voiceflow-pro-ui/src/App.tsx
+++ b/voiceflow-pro-ui/src/App.tsx
@@ -135,11 +135,6 @@ const AppContent: React.FC = () => {
     }
   };
 
-  // Handle voice recording state changes
-  const handleRecordingStateChange = (newState: any) => {
-    setRecordingState(newState);
-  };
-
   // Handle audio visualization data updates
   const handleAudioDataUpdate = (data: AudioVisualizationData) => {
     setAudioData(prev => [...prev.slice(-99), data]); // Keep last 100 data points
@@ -572,6 +567,7 @@ const AppContent: React.FC = () => {
         }}
       />
     </div>
+    </ErrorBoundary>
   );
 };
 

--- a/voiceflow-pro-ui/src/components/ErrorBoundary.tsx
+++ b/voiceflow-pro-ui/src/components/ErrorBoundary.tsx
@@ -124,9 +124,9 @@ const DefaultErrorFallback: React.FC<ErrorFallbackProps> = ({
   error, 
   resetError, 
   errorInfo, 
-  showDetails = process.env.NODE_ENV === 'development' 
+  showDetails = process.env.NODE_ENV === 'development'
 }) => {
-  const [showDetails, setShowDetails] = React.useState(false);
+  const [detailsExpanded, setDetailsExpanded] = React.useState(false);
   const errorMessage = getErrorMessage(error);
 
   return (
@@ -160,7 +160,7 @@ const DefaultErrorFallback: React.FC<ErrorFallbackProps> = ({
           </button>
           
           <button
-            onClick={handleGoHome}
+            onClick={() => { window.location.href = '/'; }}
             className="inline-flex items-center justify-center px-4 py-2 bg-gray-600 hover:bg-gray-700 text-white rounded-md transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2"
           >
             <Home className="h-4 w-4 mr-2" />
@@ -172,14 +172,14 @@ const DefaultErrorFallback: React.FC<ErrorFallbackProps> = ({
         {showDetails && (
           <div className="border-t border-gray-200 dark:border-gray-700 pt-4">
             <button
-              onClick={() => setShowDetails(!showDetails)}
+              onClick={() => setDetailsExpanded(!detailsExpanded)}
               className="inline-flex items-center text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
             >
               <Bug className="h-4 w-4 mr-1" />
-              {showDetails ? 'Hide' : 'Show'} Error Details
+              {detailsExpanded ? 'Hide' : 'Show'} Error Details
             </button>
-            
-            {showDetails && (
+
+            {detailsExpanded && (
               <div className="mt-3 p-3 bg-gray-50 dark:bg-gray-900 rounded-md">
                 <pre className="text-xs text-gray-600 dark:text-gray-400 overflow-auto max-h-48">
                   {serializeError(error)}

--- a/voiceflow-pro-ui/src/components/LazyComponent.tsx
+++ b/voiceflow-pro-ui/src/components/LazyComponent.tsx
@@ -43,8 +43,8 @@ const DefaultErrorFallback: React.FC<{ error: Error; resetError: () => void }> =
 );
 
 // Main lazy component wrapper
-export const LazyComponent: React.FC<LazyComponentProps & { 
-  component: React.LazyExoticComponent<React.ComponentType<any>>;
+export const LazyComponent: React.FC<LazyComponentProps & {
+  component: React.ComponentType<any>;
 }> = ({
   component: LazyComponent,
   children,
@@ -57,7 +57,6 @@ export const LazyComponent: React.FC<LazyComponentProps & {
   const WrappedComponent = enableErrorBoundary 
     ? (props: any) => (
         <SimpleErrorBoundary
-          fallback={ErrorFallback}
           className={className}
         >
           <LazyComponent {...props} />
@@ -106,7 +105,7 @@ export const createLazyComponent = (
   };
 
   // Component wrapper with error boundary and loading states
-  const WrappedLazyComponent: React.FC<LazyComponentProps & { [key: string]: any }> = ({
+  const WrappedLazyComponent: React.FC<LazyComponentProps & { [key: string]: any }> & { preload?: () => void } = ({
     children,
     fallback,
     errorFallback = options.errorFallback,
@@ -135,35 +134,35 @@ export const createLazyComponent = (
 
 // Specific lazy components for VoiceFlow Pro
 export const LazyVoiceRecording = createLazyComponent(
-  () => import('@/components/VoiceRecording'),
+  () => import('@/components/VoiceRecording').then(m => ({ default: m.VoiceRecording })),
   {
     fallback: <DefaultLoadingFallback message="Loading voice recording..." type="recording" />
   }
 );
 
 export const LazyTranscriptionDisplay = createLazyComponent(
-  () => import('@/components/TranscriptionDisplay'),
+  () => import('@/components/TranscriptionDisplay').then(m => ({ default: m.TranscriptionDisplay })),
   {
     fallback: <DefaultLoadingFallback message="Loading transcription..." type="general" />
   }
 );
 
 export const LazyLanguageSelector = createLazyComponent(
-  () => import('@/components/LanguageSelector'),
+  () => import('@/components/LanguageSelector').then(m => ({ default: m.LanguageSelector })),
   {
     fallback: <DefaultLoadingFallback message="Loading language options..." type="language-detection" />
   }
 );
 
 export const LazyAudioVisualization = createLazyComponent(
-  () => import('@/components/AudioVisualization'),
+  () => import('@/components/AudioVisualization').then(m => ({ default: m.AudioVisualization })),
   {
     fallback: <DefaultLoadingFallback message="Loading audio visualization..." type="audio-enhancement" />
   }
 );
 
 export const LazySettingsPanel = createLazyComponent(
-  () => import('@/components/SettingsPanel'),
+  () => import('@/components/SettingsPanel').then(m => ({ default: m.SettingsPanel })),
   {
     fallback: <DefaultLoadingFallback message="Loading settings..." type="general" />
   }
@@ -239,7 +238,8 @@ export const useComponentPreloader = () => {
 // Route-based code splitting helper
 export const useRouteBasedPreloading = () => {
   const [currentRoute, setCurrentRoute] = React.useState('');
-  
+  const { preloadComponents } = useComponentPreloader();
+
   React.useEffect(() => {
     // Preload components based on current route
     const preloadByRoute = () => {

--- a/voiceflow-pro-ui/src/components/VoiceRecording.tsx
+++ b/voiceflow-pro-ui/src/components/VoiceRecording.tsx
@@ -139,7 +139,7 @@ export const VoiceRecording: React.FC<VoiceRecordingProps> = ({
     if (hrs > 0) {
       return `${hrs}:${mins.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
     }
-    return `${mins}:${secs.toString().padFocusStyles(2, '0')}`;
+    return `${mins}:${secs.toString().padStart(2, '0')}`;
   };
 
   // Enhanced recording functions with mobile optimization and AI integration
@@ -326,7 +326,7 @@ export const VoiceRecording: React.FC<VoiceRecordingProps> = ({
     minWidth: size === 'small' ? '80px' : size === 'large' ? '120px' : '100px',
   };
 
-  const variantStyles: React.CSSProperties = {
+  const variantStyles: Record<string, React.CSSProperties> = {
     primary: {
       backgroundColor: state.isRecording ? colors.error : colors.primary,
       color: '#ffffff',

--- a/voiceflow-pro-ui/src/components/index.ts
+++ b/voiceflow-pro-ui/src/components/index.ts
@@ -15,3 +15,17 @@ export {
   LoadingOverlay 
 } from './LoadingState';
 export { ErrorBoundary, SimpleErrorBoundary, useErrorHandler } from './ErrorBoundary';
+
+// Export lazy-loading utilities and components
+export {
+  LazyComponent,
+  createLazyComponent,
+  LazyVoiceRecording,
+  LazyTranscriptionDisplay,
+  LazyLanguageSelector,
+  LazyAudioVisualization,
+  LazySettingsPanel,
+  preloadAllComponents,
+  useComponentPreloader,
+  useRouteBasedPreloading,
+} from './LazyComponent';

--- a/voiceflow-pro-ui/src/contexts/ThemeContext.tsx
+++ b/voiceflow-pro-ui/src/contexts/ThemeContext.tsx
@@ -16,8 +16,15 @@ interface ThemeContextType {
   };
   colors: Record<string, string>;
   spacing: Record<string, string>;
-  typography: Record<string, string>;
+  typography: TypographyTokens;
   borderRadius: Record<string, string>;
+}
+
+interface TypographyTokens {
+  fontFamily: string;
+  fontSize: Record<string, string>;
+  fontWeight: Record<string, number>;
+  lineHeight: Record<string, string>;
 }
 
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
@@ -175,10 +182,10 @@ const getTypography = (platform: PlatformType) => {
       '3xl': '30px',
     },
     fontWeight: {
-      normal: '400',
-      medium: '500',
-      semibold: '600',
-      bold: '700',
+      normal: 400,
+      medium: 500,
+      semibold: 600,
+      bold: 700,
     },
     lineHeight: {
       tight: '1.25',

--- a/voiceflow-pro-ui/src/hooks/useAIWorker.tsx
+++ b/voiceflow-pro-ui/src/hooks/useAIWorker.tsx
@@ -30,7 +30,7 @@ export const useAIWorker = (options: UseAIWorkerOptions = {}) => {
 
       switch (type) {
         case 'INIT_STATUS':
-          options.onInit?.(data);
+          options.onInit?.({ status: data.status, progress: data.progress, message: data.message });
           if (data.status === 'complete') {
             setIsReady(true);
           }

--- a/voiceflow-pro-ui/src/lib/utils.ts
+++ b/voiceflow-pro-ui/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]): string {
+  return twMerge(clsx(inputs));
+}

--- a/voiceflow-pro-ui/src/types/index.ts
+++ b/voiceflow-pro-ui/src/types/index.ts
@@ -1,6 +1,8 @@
 // Core Types for VoiceFlow Pro UI Components
 
-export type PlatformType = 'mac' | 'windows' | 'linux';
+import type { CSSProperties } from 'react';
+
+export type PlatformType = 'mac' | 'windows' | 'linux' | 'web';
 export type ThemeType = 'light' | 'dark' | 'auto';
 
 export interface VoiceRecordingState {
@@ -73,17 +75,17 @@ export interface AccessibilityProps {
 }
 
 export interface ComponentSize {
-  small: string;
-  medium: string;
-  large: string;
+  small: CSSProperties;
+  medium: CSSProperties;
+  large: CSSProperties;
 }
 
 export interface ComponentVariants {
-  primary: string;
-  secondary: string;
-  outline: string;
-  ghost: string;
-  destructive: string;
+  primary: CSSProperties;
+  secondary: CSSProperties;
+  outline: CSSProperties;
+  ghost: CSSProperties;
+  destructive: CSSProperties;
 }
 
 export interface PlatformConfig {

--- a/voiceflow-pro-ui/src/utils/accessibility.tsx
+++ b/voiceflow-pro-ui/src/utils/accessibility.tsx
@@ -1,6 +1,7 @@
 // Accessibility Utilities for VoiceFlow Pro
 
-import { AccessibilityProps, ComponentSize, ComponentVariants } from '@/types';
+import React from 'react';
+import { AccessibilityProps, ComponentSize, ComponentVariants, PlatformType } from '@/types';
 
 // Generate accessible color combinations
 export const generateAccessibleColors = (
@@ -46,7 +47,7 @@ const hexToRgb = (hex: string): { r: number; g: number; b: number } | null => {
 
 // Generate accessible focus styles
 export const getFocusStyles = (
-  platform: 'mac' | 'windows' | 'linux',
+  platform: PlatformType,
   highContrast = false
 ): React.CSSProperties => {
   const baseStyles: React.CSSProperties = {

--- a/voiceflow-pro-ui/tsconfig.app.json
+++ b/voiceflow-pro-ui/tsconfig.app.json
@@ -38,5 +38,8 @@
   },
   "include": [
     "src"
+  ],
+  "exclude": [
+    "src/test"
   ]
 }

--- a/voiceflow-pro-ui/vite.config.ts
+++ b/voiceflow-pro-ui/vite.config.ts
@@ -57,7 +57,7 @@ export default defineConfig({
         // Ensure consistent chunk names
         chunkFileNames: (chunkInfo) => {
           const facadeModuleId = chunkInfo.facadeModuleId
-            ? chunkInfo.facadeModuleId.split('/').pop().replace('.tsx', '').replace('.ts', '')
+            ? (chunkInfo.facadeModuleId.split('/').pop() ?? 'chunk').replace('.tsx', '').replace('.ts', '')
             : 'chunk';
           return `js/${facadeModuleId}-[hash].js`;
         },
@@ -91,8 +91,6 @@ export default defineConfig({
     } : undefined
   },
   server: {
-    // Enable compression for dev server
-    compress: true,
     // Optimize HMR
     hmr: {
       overlay: true


### PR DESCRIPTION
Makes the **ui-e2e workflow fully green** (was failing at `pnpm install`). Three layered fixes:

### 1. node:sqlite install crash
`corepack` pulled pnpm 11 (needs Node ≥22.13, uses `node:sqlite`) but the workflow pinned Node 20. Fixed: Node 20→22, pinned `packageManager: pnpm@11.9.0`, approved the esbuild build script.

### 2. voiceflow-pro-ui build (~86 TS errors, closes #9)
The project had never compiled (masked by the install failure). Root-caused, no `@ts-ignore`/silencing:
- Re-export the lazy-loading API from `./LazyComponent` (existed but unexported).
- App.tsx: missing `</ErrorBoundary>`, duplicate function removed.
- ThemeContext/types: nested typography tokens, numeric fontWeight, `'web'` in PlatformType, `CSSProperties` component tokens.
- accessibility.ts→.tsx (+React import), ErrorBoundary/LazyComponent/VoiceRecording/useAIWorker scope+type fixes, added missing `@/lib/utils` `cn()`, vite.config guards.
- Excluded `src/test` from the app build (its vitest deps aren't installed; separate concern).

### 3. Missing test runner
Added `@playwright/test` devDependency (the workflow ran `playwright test` but only the browser was installed).

## CI: ✅ all green
install ✓ · audit-ci ✓ · build ✓ · playwright install ✓ · **smoke test ✓ (1 passed)**

## Out of scope (pre-existing, separate)
- The voiceflow-pro-ui `test` script (vitest) is broken — vitest not in deps. Unrelated to ui-e2e.