### PR TITLE
test(mobile): rewrite 5 service test suites against real APIs (#7 Category A)

### DIFF
--- a/VoiceCode/apps/mobile/src/__tests__/services/AIMLService.test.ts
+++ b/VoiceCode/apps/mobile/src/__tests__/services/AIMLService.test.ts
@@ -1,259 +1,205 @@
 // VoiceCode Mobile - AIML Service Tests
+// Tests the real AIMLService: summaries, key points, action items, speakers and
+// their updates. External deps (fetch + supabase client) are mocked; the shared
+// supabase client comes from jest.setup.js and is reconfigured per test.
 
 import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 import AIMLService from '../../services/AIMLService';
 import { supabase } from '../../services/supabaseService';
 
-jest.mock('../../services/supabaseService');
-
-// Mock fetch for AI API calls
+// Mock fetch for AI API calls.
 global.fetch = jest.fn() as jest.Mock;
 
+// Chainable builder: `.single()` resolves `result`, and directly-awaited chains
+// (e.g. `.select('*').eq(...)`) resolve `result` via `.then`.
+function qb(result: { data: any; error: any }) {
+  const b: any = {};
+  ['select', 'insert', 'update', 'eq', 'order', 'limit'].forEach((m) => {
+    b[m] = jest.fn(() => b);
+  });
+  b.single = jest.fn(() => Promise.resolve(result));
+  b.then = (resolve: any, reject: any) => Promise.resolve(result).then(resolve, reject);
+  return b;
+}
+
+const authedUser = { id: 'u1' };
+
 describe('AIMLService', () => {
-  const mockTranscriptId = 'transcript-123';
-  const mockTranscriptText = 'This is a meeting about project planning. We discussed the timeline and assigned tasks to team members. John will handle the frontend. Sarah will work on the backend. We need to complete this by Friday.';
+  const transcriptId = 'transcript-123';
+  const transcriptText = 'This is a meeting about project planning with tasks and a Friday deadline.';
 
   beforeEach(() => {
     jest.clearAllMocks();
+    (supabase.auth.getUser as jest.Mock).mockResolvedValue({ data: { user: authedUser } });
   });
 
   describe('generateSummary', () => {
-    it('should generate a summary from transcript text', async () => {
-      const mockSummary = {
-        id: 'summary-1',
-        transcript_id: mockTranscriptId,
-        summary_text: 'Meeting about project planning with timeline and task assignments.',
-        confidence: 0.95,
-        created_at: '2024-01-15T10:00:00Z',
-      };
-
+    it('generates and persists a summary from transcript text', async () => {
       (global.fetch as jest.Mock).mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve({ summary: mockSummary.summary_text }),
+        json: () => Promise.resolve({ summary: 'A short summary', confidence: 0.9, model: 'gpt-4-turbo' }),
       });
 
-      (supabase.from as jest.Mock).mockReturnValue({
-        insert: jest.fn().mockReturnValue({
-          select: jest.fn().mockReturnValue({
-            single: jest.fn().mockResolvedValue({ data: mockSummary, error: null }),
-          }),
-        }),
-      });
+      const dbRow = {
+        id: 's1',
+        transcript_id: transcriptId,
+        summary_text: 'A short summary',
+        confidence: 0.9,
+        model_version: 'gpt-4-turbo',
+        created_at: '2024-01-15T10:00:00Z',
+      };
+      (supabase.from as jest.Mock)
+        .mockReturnValueOnce(qb({ data: null, error: null })) // existing check
+        .mockReturnValueOnce(qb({ data: dbRow, error: null })); // insert
 
-      const result = await AIMLService.generateSummary(mockTranscriptId, mockTranscriptText);
+      const result = await AIMLService.generateSummary(transcriptId, transcriptText);
 
-      expect(result.summaryText).toBeTruthy();
-      expect(result.confidence).toBeGreaterThan(0);
+      expect(result.summaryText).toBe('A short summary');
+      expect(result.confidence).toBeCloseTo(0.9);
+      expect(result.transcriptId).toBe(transcriptId);
     });
 
-    it('should handle API errors gracefully', async () => {
-      (global.fetch as jest.Mock).mockResolvedValue({
-        ok: false,
-        status: 500,
-        statusText: 'Internal Server Error',
-      });
+    it('returns an existing summary without calling the AI API', async () => {
+      const dbRow = {
+        id: 's1',
+        transcript_id: transcriptId,
+        summary_text: 'Cached summary',
+        confidence: 0.88,
+        created_at: '2024-01-15T10:00:00Z',
+      };
+      (supabase.from as jest.Mock).mockReturnValueOnce(qb({ data: dbRow, error: null }));
 
-      await expect(
-        AIMLService.generateSummary(mockTranscriptId, mockTranscriptText)
-      ).rejects.toThrow();
+      const result = await AIMLService.generateSummary(transcriptId, transcriptText);
+
+      expect(result.summaryText).toBe('Cached summary');
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('throws when the AI API responds with an error', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({ ok: false, statusText: 'Bad Gateway' });
+      (supabase.from as jest.Mock).mockReturnValueOnce(qb({ data: null, error: null }));
+
+      await expect(AIMLService.generateSummary(transcriptId, transcriptText)).rejects.toThrow();
+    });
+
+    it('throws when the user is not authenticated', async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({ data: { user: null } });
+
+      await expect(AIMLService.generateSummary(transcriptId, transcriptText)).rejects.toThrow(
+        'User not authenticated'
+      );
     });
   });
 
   describe('extractKeyPoints', () => {
-    it('should extract key points from transcript', async () => {
-      const mockKeyPoints = {
-        id: 'keypoints-1',
-        transcript_id: mockTranscriptId,
-        key_points: [
-          'Project planning discussion',
-          'Timeline established',
-          'John assigned to frontend',
-          'Sarah assigned to backend',
-          'Deadline is Friday',
-        ],
+    it('extracts and persists key points from transcript text', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ key_points: ['a', 'b', 'c', 'd', 'e'], confidence: 0.92 }),
+      });
+
+      const dbRow = {
+        id: 'k1',
+        transcript_id: transcriptId,
+        key_points: ['a', 'b', 'c', 'd', 'e'],
         confidence: 0.92,
         created_at: '2024-01-15T10:00:00Z',
       };
+      (supabase.from as jest.Mock)
+        .mockReturnValueOnce(qb({ data: null, error: null }))
+        .mockReturnValueOnce(qb({ data: dbRow, error: null }));
 
-      (global.fetch as jest.Mock).mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve({ keyPoints: mockKeyPoints.key_points }),
-      });
-
-      (supabase.from as jest.Mock).mockReturnValue({
-        insert: jest.fn().mockReturnValue({
-          select: jest.fn().mockReturnValue({
-            single: jest.fn().mockResolvedValue({ data: mockKeyPoints, error: null }),
-          }),
-        }),
-      });
-
-      const result = await AIMLService.extractKeyPoints(mockTranscriptId, mockTranscriptText);
+      const result = await AIMLService.extractKeyPoints(transcriptId, transcriptText);
 
       expect(result.keyPoints).toHaveLength(5);
-      expect(result.keyPoints).toContain('Project planning discussion');
+      expect(result.keyPoints[0]).toBe('a');
     });
   });
 
   describe('extractActionItems', () => {
-    it('should extract action items from transcript', async () => {
-      const mockActionItems = [
-        {
-          id: 'action-1',
-          transcript_id: mockTranscriptId,
-          text: 'John to handle frontend development',
-          assignee: 'John',
-          priority: 'high',
-          completed: false,
-          created_at: '2024-01-15T10:00:00Z',
-        },
-        {
-          id: 'action-2',
-          transcript_id: mockTranscriptId,
-          text: 'Sarah to work on backend',
-          assignee: 'Sarah',
-          priority: 'high',
-          completed: false,
-          created_at: '2024-01-15T10:00:00Z',
-        },
-      ];
-
+    it('extracts and persists action items from transcript text', async () => {
       (global.fetch as jest.Mock).mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve({ actionItems: mockActionItems }),
+        json: () =>
+          Promise.resolve({ action_items: [{ text: 'Do X', priority: 'high' }, { text: 'Do Y' }] }),
       });
 
-      (supabase.from as jest.Mock).mockReturnValue({
-        insert: jest.fn().mockReturnValue({
-          select: jest.fn().mockResolvedValue({ data: mockActionItems, error: null }),
-        }),
-      });
+      const dbRows = [
+        { id: 'a1', transcript_id: transcriptId, text: 'Do X', completed: false, priority: 'high', created_at: '2024-01-15T10:00:00Z' },
+        { id: 'a2', transcript_id: transcriptId, text: 'Do Y', completed: false, priority: 'medium', created_at: '2024-01-15T10:00:00Z' },
+      ];
+      (supabase.from as jest.Mock)
+        .mockReturnValueOnce(qb({ data: [], error: null })) // existing check (awaited chain)
+        .mockReturnValueOnce(qb({ data: dbRows, error: null })); // insert
 
-      const result = await AIMLService.extractActionItems(mockTranscriptId, mockTranscriptText);
+      const result = await AIMLService.extractActionItems(transcriptId, transcriptText);
 
       expect(result).toHaveLength(2);
-      expect(result[0].assignee).toBe('John');
-      expect(result[1].assignee).toBe('Sarah');
+      expect(result[0].text).toBe('Do X');
+      expect(result[0].completed).toBe(false);
     });
   });
 
   describe('identifySpeakers', () => {
-    it('should identify speakers from transcript', async () => {
-      const mockSpeakers = [
-        {
-          id: 'speaker-1',
-          transcript_id: mockTranscriptId,
-          name: 'John',
-          color: '#FF5733',
-          segments: [{ start: 0, end: 30 }],
-        },
-        {
-          id: 'speaker-2',
-          transcript_id: mockTranscriptId,
-          name: 'Sarah',
-          color: '#33FF57',
-          segments: [{ start: 30, end: 60 }],
-        },
-      ];
-
+    it('identifies and persists speakers from transcript text', async () => {
       (global.fetch as jest.Mock).mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve({ speakers: mockSpeakers }),
+        json: () =>
+          Promise.resolve({ speakers: [{ label: 'Speaker 1' }, { label: 'Speaker 2' }] }),
       });
 
-      (supabase.from as jest.Mock).mockReturnValue({
-        insert: jest.fn().mockReturnValue({
-          select: jest.fn().mockResolvedValue({ data: mockSpeakers, error: null }),
-        }),
-      });
-
-      const result = await AIMLService.identifySpeakers(mockTranscriptId, mockTranscriptText);
-
-      expect(result).toHaveLength(2);
-      expect(result[0].name).toBe('John');
-      expect(result[1].name).toBe('Sarah');
-    });
-  });
-
-  describe('getSummary', () => {
-    it('should retrieve existing summary', async () => {
-      const mockSummary = {
-        id: 'summary-1',
-        transcript_id: mockTranscriptId,
-        summary_text: 'Existing summary',
-        confidence: 0.95,
-        created_at: '2024-01-15T10:00:00Z',
-      };
-
-      (supabase.from as jest.Mock).mockReturnValue({
-        select: jest.fn().mockReturnValue({
-          eq: jest.fn().mockReturnValue({
-            single: jest.fn().mockResolvedValue({ data: mockSummary, error: null }),
-          }),
-        }),
-      });
-
-      const result = await AIMLService.getSummary(mockTranscriptId);
-
-      expect(result?.summaryText).toBe('Existing summary');
-    });
-
-    it('should return null if no summary exists', async () => {
-      (supabase.from as jest.Mock).mockReturnValue({
-        select: jest.fn().mockReturnValue({
-          eq: jest.fn().mockReturnValue({
-            single: jest.fn().mockResolvedValue({ data: null, error: null }),
-          }),
-        }),
-      });
-
-      const result = await AIMLService.getSummary(mockTranscriptId);
-
-      expect(result).toBeNull();
-    });
-  });
-
-  describe('getKeyPoints', () => {
-    it('should retrieve existing key points', async () => {
-      const mockKeyPoints = {
-        id: 'keypoints-1',
-        transcript_id: mockTranscriptId,
-        key_points: ['Point 1', 'Point 2'],
-        confidence: 0.90,
-        created_at: '2024-01-15T10:00:00Z',
-      };
-
-      (supabase.from as jest.Mock).mockReturnValue({
-        select: jest.fn().mockReturnValue({
-          eq: jest.fn().mockReturnValue({
-            single: jest.fn().mockResolvedValue({ data: mockKeyPoints, error: null }),
-          }),
-        }),
-      });
-
-      const result = await AIMLService.getKeyPoints(mockTranscriptId);
-
-      expect(result?.keyPoints).toHaveLength(2);
-    });
-  });
-
-  describe('getActionItems', () => {
-    it('should retrieve existing action items', async () => {
-      const mockActionItems = [
-        { id: 'action-1', text: 'Task 1', completed: false },
-        { id: 'action-2', text: 'Task 2', completed: true },
+      const dbRows = [
+        { id: 'sp1', transcript_id: transcriptId, label: 'Speaker 1', color: '#667eea', segment_count: 3, created_at: '2024-01-15T10:00:00Z' },
+        { id: 'sp2', transcript_id: transcriptId, label: 'Speaker 2', color: '#764ba2', segment_count: 2, created_at: '2024-01-15T10:00:00Z' },
       ];
+      (supabase.from as jest.Mock)
+        .mockReturnValueOnce(qb({ data: [], error: null })) // existing check
+        .mockReturnValueOnce(qb({ data: dbRows, error: null })); // insert
 
-      (supabase.from as jest.Mock).mockReturnValue({
-        select: jest.fn().mockReturnValue({
-          eq: jest.fn().mockResolvedValue({ data: mockActionItems, error: null }),
-        }),
-      });
-
-      const result = await AIMLService.getActionItems(mockTranscriptId);
+      const result = await AIMLService.identifySpeakers(transcriptId, transcriptText);
 
       expect(result).toHaveLength(2);
-      expect(result[1].completed).toBe(true);
+      expect(result[0].label).toBe('Speaker 1');
+      expect(result[0].segmentCount).toBe(3);
+    });
+  });
+
+  describe('updateActionItem', () => {
+    it('updates an action item and returns the mapped result', async () => {
+      const dbRow = {
+        id: 'a1',
+        transcript_id: transcriptId,
+        text: 'Updated task',
+        completed: true,
+        priority: 'high',
+        created_at: '2024-01-15T10:00:00Z',
+        completed_at: '2024-01-16T10:00:00Z',
+      };
+      (supabase.from as jest.Mock).mockReturnValueOnce(qb({ data: dbRow, error: null }));
+
+      const result = await AIMLService.updateActionItem('a1', { completed: true });
+
+      expect(result.completed).toBe(true);
+      expect(result.text).toBe('Updated task');
+    });
+  });
+
+  describe('updateSpeaker', () => {
+    it('updates a speaker label and color and returns the mapped result', async () => {
+      const dbRow = {
+        id: 'sp1',
+        transcript_id: transcriptId,
+        label: 'Host',
+        color: '#000000',
+        segment_count: 5,
+        created_at: '2024-01-15T10:00:00Z',
+      };
+      (supabase.from as jest.Mock).mockReturnValueOnce(qb({ data: dbRow, error: null }));
+
+      const result = await AIMLService.updateSpeaker('sp1', 'Host', '#000000');
+
+      expect(result.label).toBe('Host');
+      expect(result.color).toBe('#000000');
     });
   });
 });

--- a/VoiceCode/apps/mobile/src/__tests__/services/AudioRecorder.test.ts
+++ b/VoiceCode/apps/mobile/src/__tests__/services/AudioRecorder.test.ts
@@ -1,72 +1,113 @@
 // VoiceCode Mobile - Audio Recorder Service Tests
+// Tests the real AudioRecorder API against the mocked expo-av / expo-file-system.
 
 import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { Audio } from 'expo-av';
+import * as FileSystem from 'expo-file-system';
 import { AudioRecorder } from '../../services/AudioRecorder';
+import { RecordingStatus, RecordingQuality } from '../../types/recording';
 
 describe('AudioRecorder', () => {
   let recorder: AudioRecorder;
 
   beforeEach(() => {
-    recorder = new AudioRecorder();
     jest.clearAllMocks();
+    (FileSystem.getInfoAsync as jest.Mock).mockResolvedValue({ exists: true, size: 2048 });
+    recorder = new AudioRecorder();
   });
 
-  describe('Permissions', () => {
-    it('should request microphone permissions', async () => {
-      const result = await recorder.requestPermissions();
-      expect(result).toBeDefined();
-    });
-
-    it('should check if permissions are granted', async () => {
-      const hasPermissions = await recorder.hasPermissions();
-      expect(typeof hasPermissions).toBe('boolean');
+  describe('status', () => {
+    it('starts in the IDLE state', () => {
+      expect(recorder.getStatus()).toBe(RecordingStatus.IDLE);
     });
   });
 
-  describe('Recording', () => {
-    it('should start recording', async () => {
-      await recorder.requestPermissions();
-      const result = await recorder.startRecording();
-      expect(result).toHaveProperty('uri');
+  describe('startRecording', () => {
+    it('creates a recording and transitions to RECORDING', async () => {
+      await recorder.startRecording(RecordingQuality.HIGH);
+
+      expect(Audio.Recording.createAsync).toHaveBeenCalled();
+      expect(recorder.getStatus()).toBe(RecordingStatus.RECORDING);
     });
 
-    it('should stop recording', async () => {
-      await recorder.startRecording();
-      const result = await recorder.stopRecording();
-      expect(result).toHaveProperty('uri');
-      expect(result).toHaveProperty('duration');
-    });
+    it('throws when microphone permission is denied', async () => {
+      (Audio.requestPermissionsAsync as jest.Mock).mockResolvedValueOnce({
+        granted: false,
+        status: 'denied',
+      });
 
-    it('should pause recording', async () => {
+      await expect(recorder.startRecording()).rejects.toThrow('Microphone permission not granted');
+    });
+  });
+
+  describe('pause / resume', () => {
+    it('transitions to PAUSED when pausing an active recording', async () => {
       await recorder.startRecording();
       await recorder.pauseRecording();
-      const status = await recorder.getRecordingStatus();
-      expect(status).toBe('paused');
+
+      expect(recorder.getStatus()).toBe(RecordingStatus.PAUSED);
     });
 
-    it('should resume recording', async () => {
+    it('transitions back to RECORDING when resuming a paused recording', async () => {
       await recorder.startRecording();
       await recorder.pauseRecording();
       await recorder.resumeRecording();
-      const status = await recorder.getRecordingStatus();
-      expect(status).toBe('recording');
-    });
 
-    it('should get recording duration', async () => {
-      await recorder.startRecording();
-      const duration = await recorder.getRecordingDuration();
-      expect(typeof duration).toBe('number');
-      expect(duration).toBeGreaterThanOrEqual(0);
+      expect(recorder.getStatus()).toBe(RecordingStatus.RECORDING);
     });
   });
 
-  describe('Error Handling', () => {
-    it('should handle recording without permissions', async () => {
-      await expect(recorder.startRecording()).rejects.toThrow();
+  describe('stopRecording', () => {
+    it('returns the uri and metadata and transitions to STOPPED', async () => {
+      await recorder.startRecording();
+
+      const result = await recorder.stopRecording();
+
+      expect(result.uri).toBe('file://mock-recording.m4a');
+      expect(typeof result.metadata.duration).toBe('number');
+      expect(result.metadata.fileSize).toBe(2048);
+      expect(recorder.getStatus()).toBe(RecordingStatus.STOPPED);
     });
 
-    it('should handle stopping when not recording', async () => {
-      await expect(recorder.stopRecording()).rejects.toThrow();
+    it('throws when there is no active recording', async () => {
+      await expect(recorder.stopRecording()).rejects.toThrow('No active recording');
+    });
+  });
+
+  describe('getDuration', () => {
+    it('returns 0 while idle', () => {
+      expect(recorder.getDuration()).toBe(0);
+    });
+
+    it('returns a non-negative duration while recording', async () => {
+      await recorder.startRecording();
+      expect(recorder.getDuration()).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe('getMetering', () => {
+    it('returns metering levels while recording', async () => {
+      await recorder.startRecording();
+
+      const metering = await recorder.getMetering();
+
+      expect(metering).not.toBeNull();
+      expect(metering?.averagePower).toBe(-30);
+    });
+
+    it('returns null when not recording', async () => {
+      const metering = await recorder.getMetering();
+      expect(metering).toBeNull();
+    });
+  });
+
+  describe('cancelRecording', () => {
+    it('discards the recording and returns to IDLE', async () => {
+      await recorder.startRecording();
+
+      await recorder.cancelRecording();
+
+      expect(recorder.getStatus()).toBe(RecordingStatus.IDLE);
     });
   });
 });

--- a/VoiceCode/apps/mobile/src/__tests__/services/offlineStorageService.test.ts
+++ b/VoiceCode/apps/mobile/src/__tests__/services/offlineStorageService.test.ts
@@ -1,158 +1,175 @@
 // VoiceCode Mobile - Offline Storage Service Tests
+// The real service is IndexedDB-backed. The node test environment has no
+// IndexedDB, so we provide a minimal in-memory shim (put/get/clear are the only
+// primitives exercised) and test the real OfflineStorageService against it.
 
-import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
-import AsyncStorage from '@react-native-async-storage/async-storage';
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import { OfflineStorageService } from '../../services/offlineStorageService';
 
-jest.mock('@react-native-async-storage/async-storage');
+class FakeRequest {
+  result: any = undefined;
+  error: any = null;
+  onsuccess: ((ev: any) => void) | null = null;
+  onerror: ((ev: any) => void) | null = null;
+  onupgradeneeded: ((ev: any) => void) | null = null;
+}
+
+function succeed(req: FakeRequest, result?: any) {
+  req.result = result;
+  queueMicrotask(() => req.onsuccess && req.onsuccess({ target: req }));
+}
+
+class FakeObjectStore {
+  constructor(public keyPath: string, public data: Map<string, any>) {}
+  createIndex() {}
+  put(value: any) {
+    const req = new FakeRequest();
+    this.data.set(value[this.keyPath], value);
+    succeed(req, value[this.keyPath]);
+    return req;
+  }
+  get(key: string) {
+    const req = new FakeRequest();
+    succeed(req, this.data.get(key));
+    return req;
+  }
+  clear() {
+    const req = new FakeRequest();
+    this.data.clear();
+    succeed(req);
+    return req;
+  }
+  index() {
+    return { openCursor: () => new FakeRequest() };
+  }
+}
+
+class FakeTransaction {
+  oncomplete: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  error: any = null;
+  constructor(private db: FakeDB) {
+    queueMicrotask(() => this.oncomplete && this.oncomplete());
+  }
+  objectStore(name: string) {
+    return this.db.stores[name];
+  }
+}
+
+class FakeDB {
+  stores: Record<string, FakeObjectStore> = {};
+  objectStoreNames = { contains: (n: string) => n in this.stores };
+  createObjectStore(name: string, opts: { keyPath: string }) {
+    const store = new FakeObjectStore(opts.keyPath, new Map());
+    this.stores[name] = store;
+    return store;
+  }
+  transaction() {
+    return new FakeTransaction(this);
+  }
+}
+
+(global as any).indexedDB = {
+  open() {
+    const req = new FakeRequest();
+    const db = new FakeDB();
+    queueMicrotask(() => {
+      req.onupgradeneeded && req.onupgradeneeded({ target: { result: db } });
+      req.result = db;
+      req.onsuccess && req.onsuccess({ target: req });
+    });
+    return req;
+  },
+};
+(global as any).IDBKeyRange = { only: (v: any) => v };
+
+const makeTranscript = (id: string) =>
+  ({
+    id,
+    user_id: 'u1',
+    audio_url: '',
+    text: 'World',
+    content: 'World',
+    title: 'Hello',
+    duration: 10,
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+  }) as any;
 
 describe('OfflineStorageService', () => {
+  let storage: OfflineStorageService;
+
   beforeEach(() => {
-    jest.clearAllMocks();
+    storage = new OfflineStorageService();
   });
 
-  afterEach(() => {
-    jest.restoreAllMocks();
+  describe('saveTranscript / getTranscript', () => {
+    it('round-trips a saved transcript', async () => {
+      const transcript = makeTranscript('t1');
+
+      await storage.saveTranscript(transcript);
+      const result = await storage.getTranscript('t1');
+
+      expect(result).toEqual(transcript);
+    });
+
+    it('returns null for a non-existent transcript', async () => {
+      const result = await storage.getTranscript('does-not-exist');
+      expect(result).toBeNull();
+    });
   });
 
-  describe('saveTranscript', () => {
-    it('should save transcript to local storage', async () => {
-      const transcript = {
-        id: 'transcript-1',
-        title: 'Test Transcript',
-        text: 'Hello world',
-        createdAt: '2024-01-15T10:00:00Z',
-      };
+  describe('updateTranscript', () => {
+    it('merges updates onto an existing transcript', async () => {
+      await storage.saveTranscript(makeTranscript('t1'));
 
-      (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
+      await storage.updateTranscript('t1', { title: 'Changed' });
+      const result = await storage.getTranscript('t1');
 
-      // Call would be: await offlineStorageService.saveTranscript(transcript);
+      expect(result?.title).toBe('Changed');
+      expect(result?.content).toBe('World');
+    });
 
-      expect(AsyncStorage.setItem).toHaveBeenCalledWith(
-        'transcript_transcript-1',
-        JSON.stringify(transcript)
+    it('throws when updating a transcript that does not exist', async () => {
+      await expect(storage.updateTranscript('ghost', { title: 'x' })).rejects.toThrow(
+        'Transcript not found'
       );
-    });
-
-    it('should handle storage errors', async () => {
-      (AsyncStorage.setItem as jest.Mock).mockRejectedValue(new Error('Storage full'));
-
-      // await expect(offlineStorageService.saveTranscript({})).rejects.toThrow('Storage full');
-      expect(true).toBe(true); // Placeholder
-    });
-  });
-
-  describe('getTranscript', () => {
-    it('should retrieve transcript from storage', async () => {
-      const transcript = { id: 'transcript-1', title: 'Test' };
-      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(JSON.stringify(transcript));
-
-      // const result = await offlineStorageService.getTranscript('transcript-1');
-      // expect(result).toEqual(transcript);
-      expect(true).toBe(true);
-    });
-
-    it('should return null for non-existent transcript', async () => {
-      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
-
-      // const result = await offlineStorageService.getTranscript('non-existent');
-      // expect(result).toBeNull();
-      expect(true).toBe(true);
-    });
-  });
-
-  describe('getAllTranscripts', () => {
-    it('should retrieve all transcripts', async () => {
-      const keys = ['transcript_1', 'transcript_2', 'other_key'];
-      const transcripts = [
-        { id: '1', title: 'First' },
-        { id: '2', title: 'Second' },
-      ];
-
-      (AsyncStorage.getAllKeys as jest.Mock).mockResolvedValue(keys);
-      (AsyncStorage.multiGet as jest.Mock).mockResolvedValue([
-        ['transcript_1', JSON.stringify(transcripts[0])],
-        ['transcript_2', JSON.stringify(transcripts[1])],
-      ]);
-
-      // const result = await offlineStorageService.getAllTranscripts();
-      // expect(result).toHaveLength(2);
-      expect(true).toBe(true);
     });
   });
 
   describe('deleteTranscript', () => {
-    it('should delete transcript from storage', async () => {
-      (AsyncStorage.removeItem as jest.Mock).mockResolvedValue(undefined);
+    it('soft-deletes by setting is_deleted', async () => {
+      await storage.saveTranscript(makeTranscript('t1'));
 
-      // await offlineStorageService.deleteTranscript('transcript-1');
-      // expect(AsyncStorage.removeItem).toHaveBeenCalledWith('transcript_transcript-1');
-      expect(true).toBe(true);
+      await storage.deleteTranscript('t1');
+      const result = await storage.getTranscript('t1');
+
+      expect(result?.is_deleted).toBe(true);
     });
   });
 
-  describe('saveAudio', () => {
-    it('should save audio file reference', async () => {
-      const audioRef = {
-        id: 'audio-1',
-        uri: 'file:///audio.m4a',
-        size: 1024000,
-      };
+  describe('metadata', () => {
+    it('round-trips saved metadata', async () => {
+      await storage.saveMetadata('lastSync', { at: 123 });
+      const value = await storage.getMetadata('lastSync');
 
-      (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
-
-      // await offlineStorageService.saveAudio(audioRef);
-      expect(true).toBe(true);
+      expect(value).toEqual({ at: 123 });
     });
-  });
 
-  describe('getStorageUsage', () => {
-    it('should calculate total storage usage', async () => {
-      const keys = ['transcript_1', 'transcript_2'];
-      (AsyncStorage.getAllKeys as jest.Mock).mockResolvedValue(keys);
-      (AsyncStorage.multiGet as jest.Mock).mockResolvedValue([
-        ['transcript_1', JSON.stringify({ id: '1', text: 'A'.repeat(1000) })],
-        ['transcript_2', JSON.stringify({ id: '2', text: 'B'.repeat(2000) })],
-      ]);
-
-      // const usage = await offlineStorageService.getStorageUsage();
-      // expect(usage.bytes).toBeGreaterThan(0);
-      expect(true).toBe(true);
+    it('returns null for a missing metadata key', async () => {
+      const value = await storage.getMetadata('missing');
+      expect(value).toBeNull();
     });
   });
 
   describe('clearAll', () => {
-    it('should clear all offline data', async () => {
-      (AsyncStorage.clear as jest.Mock).mockResolvedValue(undefined);
+    it('removes stored transcripts', async () => {
+      await storage.saveTranscript(makeTranscript('t1'));
 
-      // await offlineStorageService.clearAll();
-      // expect(AsyncStorage.clear).toHaveBeenCalled();
-      expect(true).toBe(true);
-    });
-  });
+      await storage.clearAll();
+      const result = await storage.getTranscript('t1');
 
-  describe('getPendingUploads', () => {
-    it('should return transcripts pending upload', async () => {
-      const pending = [
-        { id: '1', synced: false },
-        { id: '2', synced: false },
-      ];
-
-      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(JSON.stringify(pending));
-
-      // const result = await offlineStorageService.getPendingUploads();
-      // expect(result).toHaveLength(2);
-      expect(true).toBe(true);
-    });
-  });
-
-  describe('markAsSynced', () => {
-    it('should mark transcript as synced', async () => {
-      const transcript = { id: '1', synced: false };
-      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(JSON.stringify(transcript));
-      (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
-
-      // await offlineStorageService.markAsSynced('1');
-      expect(true).toBe(true);
+      expect(result).toBeNull();
     });
   });
 });

--- a/VoiceCode/apps/mobile/src/__tests__/services/supabase.service.test.ts
+++ b/VoiceCode/apps/mobile/src/__tests__/services/supabase.service.test.ts
@@ -1,340 +1,242 @@
 // VoiceCode Mobile - Supabase Service Tests
-// Comprehensive tests for Supabase integration
+// Tests the real SupabaseService class API (auth + transcript CRUD + search).
+// The service reads env vars at construction; since they are absent in tests we
+// inject a controllable mock client onto the instance.
 
-import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
-import { getSupabaseService } from '../../services/supabase.service';
-import { mockUsers, mockTranscripts, mockErrors } from '../setup/mockData';
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { getSupabaseService } from '../../services/supabaseService';
 
-const supabaseService = getSupabaseService();
+const service = getSupabaseService();
 
-// Mock Supabase client
-jest.mock('@supabase/supabase-js', () => ({
-  createClient: jest.fn(() => ({
+// A chainable query-builder whose terminal call resolves to `result`.
+// Covers both `.single()` terminals and directly-awaited chains (`.range()`, `.eq()`, `.limit()`).
+function queryResult(result: { data: any; error: any }) {
+  const qb: any = {};
+  ['select', 'insert', 'update', 'upsert', 'delete', 'eq', 'neq', 'or', 'order', 'range', 'limit'].forEach(
+    (m) => {
+      qb[m] = jest.fn(() => qb);
+    }
+  );
+  qb.single = jest.fn(() => Promise.resolve(result));
+  qb.then = (resolve: any, reject: any) => Promise.resolve(result).then(resolve, reject);
+  return qb;
+}
+
+function mockClient() {
+  return {
     auth: {
-      signInWithPassword: jest.fn(),
       signUp: jest.fn(),
-      signOut: jest.fn(),
-      getSession: jest.fn(),
+      signInWithPassword: jest.fn(),
+      signOut: jest.fn(() => Promise.resolve({ error: null })),
       onAuthStateChange: jest.fn(),
-      resetPasswordForEmail: jest.fn(),
     },
-    from: jest.fn(() => ({
-      select: jest.fn().mockReturnThis(),
-      insert: jest.fn().mockReturnThis(),
-      update: jest.fn().mockReturnThis(),
-      delete: jest.fn().mockReturnThis(),
-      eq: jest.fn().mockReturnThis(),
-      single: jest.fn(),
-      order: jest.fn().mockReturnThis(),
-      limit: jest.fn().mockReturnThis(),
-    })),
-    storage: {
-      from: jest.fn(() => ({
-        upload: jest.fn(),
-        download: jest.fn(),
-        remove: jest.fn(),
-        getPublicUrl: jest.fn(),
-      })),
-    },
-  })),
-}));
+    from: jest.fn(() => queryResult({ data: null, error: null })),
+  } as any;
+}
 
 describe('SupabaseService', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    (service as any).client = null;
+    (service as any).currentUser = null;
+    (service as any).isInitialized = false;
   });
 
   describe('Authentication', () => {
-    it('should sign in with email and password', async () => {
-      const mockResponse = {
-        data: {
-          user: mockUsers.standard,
-          session: { access_token: 'mock-token' },
-        },
-        error: null,
-      };
+    it('signs in, returns the session, and stores the current user', async () => {
+      const session = { access_token: 'mock-token', user: { id: 'u1' } };
+      const client = mockClient();
+      client.auth.signInWithPassword = jest
+        .fn()
+        .mockResolvedValue({ data: { user: { id: 'u1' }, session }, error: null });
+      (service as any).client = client;
 
-      // Mock implementation
-      const signInMock = jest.fn().mockResolvedValue(mockResponse);
-      (supabaseService as any).client.auth.signInWithPassword = signInMock;
+      const result = await service.signIn('test@example.com', 'password123');
 
-      const result = await supabaseService.signIn('test@example.com', 'password123');
-
-      expect(signInMock).toHaveBeenCalledWith({
+      expect(client.auth.signInWithPassword).toHaveBeenCalledWith({
         email: 'test@example.com',
         password: 'password123',
       });
-      expect(result.data?.user).toEqual(mockUsers.standard);
+      expect(result).toEqual(session);
+      expect(service.getCurrentUser()).toEqual({ id: 'u1' });
     });
 
-    it('should handle sign in errors', async () => {
-      const mockResponse = {
-        data: null,
-        error: mockErrors.auth,
-      };
+    it('throws when sign in returns an auth error', async () => {
+      const client = mockClient();
+      client.auth.signInWithPassword = jest
+        .fn()
+        .mockResolvedValue({ data: {}, error: new Error('Invalid login credentials') });
+      (service as any).client = client;
 
-      const signInMock = jest.fn().mockResolvedValue(mockResponse);
-      (supabaseService as any).client.auth.signInWithPassword = signInMock;
-
-      const result = await supabaseService.signIn('test@example.com', 'wrong-password');
-
-      expect(result.error).toEqual(mockErrors.auth);
-      expect(result.data).toBeNull();
+      await expect(service.signIn('test@example.com', 'wrong')).rejects.toThrow(
+        'Invalid login credentials'
+      );
     });
 
-    it('should sign up new user', async () => {
-      const mockResponse = {
-        data: {
-          user: mockUsers.standard,
-          session: { access_token: 'mock-token' },
-        },
-        error: null,
-      };
+    it('throws when sign in succeeds but no session is returned', async () => {
+      const client = mockClient();
+      client.auth.signInWithPassword = jest
+        .fn()
+        .mockResolvedValue({ data: { user: null, session: null }, error: null });
+      (service as any).client = client;
 
-      const signUpMock = jest.fn().mockResolvedValue(mockResponse);
-      (supabaseService as any).client.auth.signUp = signUpMock;
-
-      const result = await supabaseService.signUp('new@example.com', 'password123');
-
-      expect(signUpMock).toHaveBeenCalledWith({
-        email: 'new@example.com',
-        password: 'password123',
-      });
-      expect(result.data?.user).toEqual(mockUsers.standard);
+      await expect(service.signIn('test@example.com', 'password123')).rejects.toThrow(
+        'Failed to create session'
+      );
     });
 
-    it('should sign out user', async () => {
-      const signOutMock = jest.fn().mockResolvedValue({ error: null });
-      (supabaseService as any).client.auth.signOut = signOutMock;
+    it('signs up a new user and creates their profile', async () => {
+      const client = mockClient();
+      client.auth.signUp = jest
+        .fn()
+        .mockResolvedValue({ data: { user: { id: 'u1' } }, error: null });
+      (service as any).client = client;
 
-      await supabaseService.signOut();
+      const user = await service.signUp('new@example.com', 'password123', 'Neo');
 
-      expect(signOutMock).toHaveBeenCalled();
+      expect(client.auth.signUp).toHaveBeenCalled();
+      expect(user).toEqual({ id: 'u1' });
+      expect(client.from).toHaveBeenCalledWith('user_profiles');
     });
 
-    it('should get current session', async () => {
-      const mockSession = {
-        access_token: 'mock-token',
-        user: mockUsers.standard,
-      };
+    it('throws when sign up returns an auth error', async () => {
+      const client = mockClient();
+      client.auth.signUp = jest
+        .fn()
+        .mockResolvedValue({ data: {}, error: new Error('Email already registered') });
+      (service as any).client = client;
 
-      const getSessionMock = jest.fn().mockResolvedValue({
-        data: { session: mockSession },
-        error: null,
-      });
-      (supabaseService as any).client.auth.getSession = getSessionMock;
-
-      const result = await supabaseService.getSession();
-
-      expect(result.data?.session).toEqual(mockSession);
+      await expect(service.signUp('new@example.com', 'password123')).rejects.toThrow(
+        'Email already registered'
+      );
     });
 
-    it('should reset password', async () => {
-      const resetMock = jest.fn().mockResolvedValue({
-        data: {},
-        error: null,
-      });
-      (supabaseService as any).client.auth.resetPasswordForEmail = resetMock;
+    it('signs out and clears the current user', async () => {
+      const client = mockClient();
+      client.auth.signOut = jest.fn().mockResolvedValue({ error: null });
+      (service as any).client = client;
+      (service as any).currentUser = { id: 'u1' };
 
-      await supabaseService.resetPassword('test@example.com');
+      await service.signOut();
 
-      expect(resetMock).toHaveBeenCalledWith('test@example.com');
+      expect(client.auth.signOut).toHaveBeenCalled();
+      expect(service.getCurrentUser()).toBeNull();
+    });
+
+    it('reports availability based on initialization state', () => {
+      (service as any).client = mockClient();
+      (service as any).isInitialized = true;
+      expect(service.isAvailable()).toBe(true);
+
+      (service as any).isInitialized = false;
+      expect(service.isAvailable()).toBe(false);
     });
   });
 
-  describe('Database Operations', () => {
-    it('should fetch transcripts for user', async () => {
-      const mockResponse = {
-        data: mockTranscripts,
-        error: null,
-      };
+  describe('User profile', () => {
+    it('fetches a user profile by id', async () => {
+      const profile = { id: 'u1', email: 'test@example.com' };
+      const client = mockClient();
+      client.from = jest.fn(() => queryResult({ data: profile, error: null }));
+      (service as any).client = client;
 
-      const fromMock = jest.fn(() => ({
-        select: jest.fn().mockReturnThis(),
-        eq: jest.fn().mockReturnThis(),
-        order: jest.fn().mockResolvedValue(mockResponse),
-      }));
-      (supabaseService as any).client.from = fromMock;
+      const result = await service.getUserProfile('u1');
 
-      const result = await supabaseService.getTranscripts('user-1');
-
-      expect(fromMock).toHaveBeenCalledWith('transcripts');
-      expect(result.data).toEqual(mockTranscripts);
+      expect(client.from).toHaveBeenCalledWith('user_profiles');
+      expect(result).toEqual(profile);
     });
 
-    it('should create new transcript', async () => {
-      const newTranscript = {
-        user_id: 'user-1',
-        title: 'New Recording',
-        content: 'Transcript content',
-        duration: 120,
-      };
+    it('throws when no user id is available', async () => {
+      (service as any).client = mockClient();
+      (service as any).currentUser = null;
 
-      const mockResponse = {
-        data: { ...newTranscript, id: 'new-id' },
-        error: null,
-      };
-
-      const fromMock = jest.fn(() => ({
-        insert: jest.fn().mockReturnThis(),
-        select: jest.fn().mockReturnThis(),
-        single: jest.fn().mockResolvedValue(mockResponse),
-      }));
-      (supabaseService as any).client.from = fromMock;
-
-      const result = await supabaseService.createTranscript(newTranscript);
-
-      expect(result.data).toHaveProperty('id');
-      expect(result.data?.title).toBe('New Recording');
-    });
-
-    it('should update transcript', async () => {
-      const updates = {
-        title: 'Updated Title',
-        content: 'Updated content',
-      };
-
-      const mockResponse = {
-        data: { ...mockTranscripts[0], ...updates },
-        error: null,
-      };
-
-      const fromMock = jest.fn(() => ({
-        update: jest.fn().mockReturnThis(),
-        eq: jest.fn().mockReturnThis(),
-        select: jest.fn().mockReturnThis(),
-        single: jest.fn().mockResolvedValue(mockResponse),
-      }));
-      (supabaseService as any).client.from = fromMock;
-
-      const result = await supabaseService.updateTranscript('transcript-1', updates);
-
-      expect(result.data?.title).toBe('Updated Title');
-    });
-
-    it('should delete transcript', async () => {
-      const mockResponse = {
-        data: null,
-        error: null,
-      };
-
-      const fromMock = jest.fn(() => ({
-        delete: jest.fn().mockReturnThis(),
-        eq: jest.fn().mockResolvedValue(mockResponse),
-      }));
-      (supabaseService as any).client.from = fromMock;
-
-      const result = await supabaseService.deleteTranscript('transcript-1');
-
-      expect(result.error).toBeNull();
-    });
-
-    it('should handle database errors', async () => {
-      const mockResponse = {
-        data: null,
-        error: mockErrors.server,
-      };
-
-      const fromMock = jest.fn(() => ({
-        select: jest.fn().mockReturnThis(),
-        eq: jest.fn().mockReturnThis(),
-        order: jest.fn().mockResolvedValue(mockResponse),
-      }));
-      (supabaseService as any).client.from = fromMock;
-
-      const result = await supabaseService.getTranscripts('user-1');
-
-      expect(result.error).toEqual(mockErrors.server);
-      expect(result.data).toBeNull();
+      await expect(service.getUserProfile()).rejects.toThrow('No user ID provided');
     });
   });
 
-  describe('Storage Operations', () => {
-    it('should upload audio file', async () => {
-      const mockFile = {
-        uri: 'file://path/to/audio.m4a',
-        name: 'audio.m4a',
-        type: 'audio/m4a',
-      };
+  describe('Transcript operations', () => {
+    it('saves a transcript for the current user', async () => {
+      const saved = { id: 't1', title: 'New Recording', user_id: 'u1' };
+      const client = mockClient();
+      client.from = jest.fn(() => queryResult({ data: saved, error: null }));
+      (service as any).client = client;
+      (service as any).currentUser = { id: 'u1' };
 
-      const mockResponse = {
-        data: { path: 'uploads/audio.m4a' },
-        error: null,
-      };
+      const result = await service.saveTranscript({ title: 'New Recording', content: 'x' } as any);
 
-      const storageMock = {
-        from: jest.fn(() => ({
-          upload: jest.fn().mockResolvedValue(mockResponse),
-        })),
-      };
-      (supabaseService as any).client.storage = storageMock;
-
-      const result = await supabaseService.uploadAudio(mockFile, 'user-1');
-
-      expect(result.data?.path).toBe('uploads/audio.m4a');
+      expect(client.from).toHaveBeenCalledWith('transcripts');
+      expect(result).toEqual(saved);
     });
 
-    it('should get public URL for file', async () => {
-      const mockResponse = {
-        data: { publicUrl: 'https://example.com/file.m4a' },
-      };
+    it('throws when saving a transcript with no user logged in', async () => {
+      (service as any).client = mockClient();
+      (service as any).currentUser = null;
 
-      const storageMock = {
-        from: jest.fn(() => ({
-          getPublicUrl: jest.fn().mockReturnValue(mockResponse),
-        })),
-      };
-      (supabaseService as any).client.storage = storageMock;
-
-      const url = await supabaseService.getPublicUrl('uploads/audio.m4a');
-
-      expect(url).toBe('https://example.com/file.m4a');
+      await expect(service.saveTranscript({} as any)).rejects.toThrow('No user logged in');
     });
 
-    it('should delete file from storage', async () => {
-      const mockResponse = {
-        data: null,
-        error: null,
-      };
+    it('lists transcripts for the current user', async () => {
+      const rows = [{ id: 't1' }, { id: 't2' }];
+      const client = mockClient();
+      client.from = jest.fn(() => queryResult({ data: rows, error: null }));
+      (service as any).client = client;
+      (service as any).currentUser = { id: 'u1' };
 
-      const storageMock = {
-        from: jest.fn(() => ({
-          remove: jest.fn().mockResolvedValue(mockResponse),
-        })),
-      };
-      (supabaseService as any).client.storage = storageMock;
+      const result = await service.getTranscripts();
 
-      const result = await supabaseService.deleteFile('uploads/audio.m4a');
-
-      expect(result.error).toBeNull();
-    });
-  });
-
-  describe('Real-time Subscriptions', () => {
-    it('should subscribe to transcript changes', () => {
-      const callback = jest.fn();
-      const mockSubscription = {
-        on: jest.fn().mockReturnThis(),
-        subscribe: jest.fn(),
-      };
-
-      const fromMock = jest.fn(() => mockSubscription);
-      (supabaseService as any).client.from = fromMock;
-
-      supabaseService.subscribeToTranscripts('user-1', callback);
-
-      expect(fromMock).toHaveBeenCalledWith('transcripts');
-      expect(mockSubscription.on).toHaveBeenCalled();
+      expect(client.from).toHaveBeenCalledWith('transcripts');
+      expect(result).toEqual(rows);
     });
 
-    it('should unsubscribe from changes', () => {
-      const mockSubscription = {
-        unsubscribe: jest.fn(),
-      };
+    it('fetches a single transcript by id', async () => {
+      const row = { id: 't1', title: 'Hello' };
+      const client = mockClient();
+      client.from = jest.fn(() => queryResult({ data: row, error: null }));
+      (service as any).client = client;
 
-      supabaseService.unsubscribe(mockSubscription as any);
+      const result = await service.getTranscript('t1');
 
-      expect(mockSubscription.unsubscribe).toHaveBeenCalled();
+      expect(result).toEqual(row);
+    });
+
+    it('throws when fetching a transcript hits a database error', async () => {
+      const client = mockClient();
+      client.from = jest.fn(() => queryResult({ data: null, error: new Error('DB unavailable') }));
+      (service as any).client = client;
+
+      await expect(service.getTranscript('t1')).rejects.toThrow('DB unavailable');
+    });
+
+    it('updates a transcript and returns the updated row', async () => {
+      const updated = { id: 't1', title: 'Updated Title' };
+      const client = mockClient();
+      client.from = jest.fn(() => queryResult({ data: updated, error: null }));
+      (service as any).client = client;
+
+      const result = await service.updateTranscript('t1', { title: 'Updated Title' });
+
+      expect(result).toEqual(updated);
+    });
+
+    it('soft-deletes a transcript without throwing', async () => {
+      const client = mockClient();
+      client.from = jest.fn(() => queryResult({ data: null, error: null }));
+      (service as any).client = client;
+
+      await expect(service.deleteTranscript('t1')).resolves.toBeUndefined();
+      expect(client.from).toHaveBeenCalledWith('transcripts');
+    });
+
+    it('searches transcripts for the current user', async () => {
+      const rows = [{ id: 't1', title: 'meeting notes' }];
+      const client = mockClient();
+      client.from = jest.fn(() => queryResult({ data: rows, error: null }));
+      (service as any).client = client;
+      (service as any).currentUser = { id: 'u1' };
+
+      const result = await service.searchTranscripts('meeting');
+
+      expect(result).toEqual(rows);
     });
   });
 });

--- a/VoiceCode/apps/mobile/src/__tests__/services/syncService.test.ts
+++ b/VoiceCode/apps/mobile/src/__tests__/services/syncService.test.ts
@@ -1,190 +1,157 @@
 // VoiceCode Mobile - Sync Service Tests
+// Tests the real SyncService API: queue management, sync execution, events,
+// status reporting and conflict resolution.
 
-import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { describe, it, expect, jest, beforeEach, afterAll } from '@jest/globals';
 import { getSyncService } from '../../services/syncService';
-import { supabase } from '../../services/supabaseService';
-import AsyncStorage from '@react-native-async-storage/async-storage';
 
-jest.mock('../../services/supabaseService');
-jest.mock('@react-native-async-storage/async-storage');
+const syncService = getSyncService();
 
 describe('SyncService', () => {
-  const syncService = getSyncService();
-  const mockUserId = 'user-123';
-
   beforeEach(() => {
     jest.clearAllMocks();
+    // Keep tests deterministic: no background timer, no auto-trigger on enqueue.
+    syncService.stopAutoSync();
+    syncService.setAutoSync(false);
+    syncService.clearQueue();
+    (syncService as any).isSyncing = false;
   });
 
-  describe('syncToCloud', () => {
-    it('should sync local data to cloud', async () => {
-      const localTranscripts = [
-        { id: 'local-1', title: 'Local Transcript', synced: false },
-      ];
+  afterAll(() => {
+    syncService.stopAutoSync();
+  });
 
-      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(
-        JSON.stringify(localTranscripts)
-      );
-
-      (supabase.from as jest.Mock).mockReturnValue({
-        upsert: jest.fn().mockResolvedValue({ data: localTranscripts, error: null }),
+  describe('getStatus', () => {
+    it('reports an idle status with no pending items initially', () => {
+      const status = syncService.getStatus();
+      expect(status).toMatchObject({
+        isSyncing: false,
+        pendingItems: 0,
+        autoSync: false,
       });
-
-      const result = await syncService.syncToCloud(mockUserId);
-
-      expect(result.synced).toBe(1);
-      expect(result.failed).toBe(0);
-    });
-
-    it('should handle sync failures gracefully', async () => {
-      const localTranscripts = [
-        { id: 'local-1', title: 'Local Transcript', synced: false },
-      ];
-
-      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(
-        JSON.stringify(localTranscripts)
-      );
-
-      (supabase.from as jest.Mock).mockReturnValue({
-        upsert: jest.fn().mockResolvedValue({ data: null, error: new Error('Sync failed') }),
-      });
-
-      const result = await syncService.syncToCloud(mockUserId);
-
-      expect(result.failed).toBe(1);
     });
   });
 
-  describe('syncFromCloud', () => {
-    it('should sync cloud data to local', async () => {
-      const cloudTranscripts = [
-        { id: 'cloud-1', title: 'Cloud Transcript', updated_at: '2024-01-15T10:00:00Z' },
-      ];
+  describe('addToQueue / getPendingCount', () => {
+    it('increments the pending count when auto-sync is disabled', () => {
+      syncService.addToQueue('create', { id: 't1', title: 'A' });
+      expect(syncService.getPendingCount()).toBe(1);
+    });
 
-      (supabase.from as jest.Mock).mockReturnValue({
-        select: jest.fn().mockReturnValue({
-          eq: jest.fn().mockReturnValue({
-            gt: jest.fn().mockResolvedValue({ data: cloudTranscripts, error: null }),
-          }),
-        }),
-      });
-
-      (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
-
-      const result = await syncService.syncFromCloud(mockUserId);
-
-      expect(result.downloaded).toBe(1);
+    it('tracks multiple queued actions in the status report', () => {
+      syncService.addToQueue('create', { id: 't1' });
+      syncService.addToQueue('update', { id: 't2' });
+      expect(syncService.getPendingCount()).toBe(2);
+      expect(syncService.getStatus().pendingItems).toBe(2);
     });
   });
 
-  describe('getLastSyncTime', () => {
-    it('should return last sync timestamp', async () => {
-      const lastSync = '2024-01-15T10:00:00Z';
-      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(lastSync);
-
-      const result = await syncService.getLastSyncTime();
-
-      expect(result).toBe(lastSync);
-    });
-
-    it('should return null if never synced', async () => {
-      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
-
-      const result = await syncService.getLastSyncTime();
-
-      expect(result).toBeNull();
+  describe('clearQueue', () => {
+    it('removes all pending items from the queue', () => {
+      syncService.addToQueue('create', { id: 't1' });
+      syncService.addToQueue('create', { id: 't2' });
+      syncService.clearQueue();
+      expect(syncService.getPendingCount()).toBe(0);
     });
   });
 
-  describe('setLastSyncTime', () => {
-    it('should store sync timestamp', async () => {
-      (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
+  describe('sync', () => {
+    it('processes queued items, empties the queue, and reports the uploaded count', async () => {
+      syncService.addToQueue('create', { id: 't1', title: 'A' });
 
-      await syncService.setLastSyncTime();
+      const result = await syncService.sync();
 
-      expect(AsyncStorage.setItem).toHaveBeenCalled();
+      expect(result.uploaded).toBe(1);
+      expect(result.errors).toBe(0);
+      expect(result).toHaveProperty('duration');
+      expect(syncService.getPendingCount()).toBe(0);
+    });
+
+    it('emits sync:start and sync:complete events during a sync', async () => {
+      const onStart = jest.fn();
+      const onComplete = jest.fn();
+      syncService.on('sync:start', onStart);
+      syncService.on('sync:complete', onComplete);
+
+      await syncService.sync();
+
+      expect(onStart).toHaveBeenCalledTimes(1);
+      expect(onComplete).toHaveBeenCalledTimes(1);
+
+      syncService.off('sync:start', onStart);
+      syncService.off('sync:complete', onComplete);
+    });
+
+    it('rejects when a sync is already in progress', async () => {
+      (syncService as any).isSyncing = true;
+
+      await expect(syncService.sync()).rejects.toThrow('Sync already in progress');
+
+      (syncService as any).isSyncing = false;
+    });
+
+    it('keeps a failing item queued for retry and reports zero uploads', async () => {
+      const originalSupabase = (syncService as any).supabase;
+      (syncService as any).supabase = {
+        from: jest.fn(() => ({
+          insert: jest.fn(() => Promise.reject(new Error('network error'))),
+        })),
+      };
+
+      syncService.addToQueue('create', { id: 't-fail' });
+      const result = await syncService.sync();
+
+      expect(result.uploaded).toBe(0);
+      expect(syncService.getPendingCount()).toBe(1);
+
+      (syncService as any).supabase = originalSupabase;
+      syncService.clearQueue();
     });
   });
 
-  describe('getPendingChanges', () => {
-    it('should return unsynced local changes', async () => {
-      const pendingChanges = [
-        { id: 'local-1', title: 'Unsynced', synced: false },
-      ];
+  describe('syncNow', () => {
+    it('delegates to sync and resolves with a result for an empty queue', async () => {
+      const result = await syncService.syncNow();
 
-      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(
-        JSON.stringify(pendingChanges)
-      );
+      expect(result.uploaded).toBe(0);
+      expect(result).toHaveProperty('duration');
+    });
+  });
 
-      const result = await syncService.getPendingChanges();
+  describe('setAutoSync', () => {
+    it('reflects the auto-sync flag in the status report', () => {
+      syncService.setAutoSync(true);
+      expect(syncService.getStatus().autoSync).toBe(true);
 
-      expect(result).toHaveLength(1);
-      expect(result[0].synced).toBe(false);
+      syncService.setAutoSync(false);
+      expect(syncService.getStatus().autoSync).toBe(false);
     });
   });
 
   describe('resolveConflict', () => {
-    it('should resolve conflict with local version', async () => {
-      const localVersion = { id: '1', title: 'Local', updated_at: '2024-01-15T12:00:00Z' };
-      const cloudVersion = { id: '1', title: 'Cloud', updated_at: '2024-01-15T10:00:00Z' };
+    it('writes the resolved transcript to the remote transcriptions table', async () => {
+      const fromSpy = (syncService as any).supabase.from;
+      const conflict = {
+        id: '1',
+        local: {
+          id: '1',
+          title: 'Local',
+          content: 'Local content',
+          updated_at: '2024-01-15T12:00:00Z',
+          metadata: {},
+        },
+        remote: {
+          id: '1',
+          title: 'Remote',
+          content: 'Remote content',
+          updated_at: '2024-01-15T10:00:00Z',
+          metadata: {},
+        },
+      };
 
-      const result = await syncService.resolveConflict(localVersion, cloudVersion, 'local');
+      await syncService.resolveConflict(conflict as any, 'local');
 
-      expect(result.title).toBe('Local');
-    });
-
-    it('should resolve conflict with cloud version', async () => {
-      const localVersion = { id: '1', title: 'Local', updated_at: '2024-01-15T10:00:00Z' };
-      const cloudVersion = { id: '1', title: 'Cloud', updated_at: '2024-01-15T12:00:00Z' };
-
-      const result = await syncService.resolveConflict(localVersion, cloudVersion, 'cloud');
-
-      expect(result.title).toBe('Cloud');
-    });
-
-    it('should auto-resolve using latest version', async () => {
-      const localVersion = { id: '1', title: 'Local', updated_at: '2024-01-15T10:00:00Z' };
-      const cloudVersion = { id: '1', title: 'Cloud', updated_at: '2024-01-15T12:00:00Z' };
-
-      const result = await syncService.resolveConflict(localVersion, cloudVersion, 'latest');
-
-      expect(result.title).toBe('Cloud'); // Cloud is more recent
-    });
-  });
-
-  describe('fullSync', () => {
-    it('should perform full bidirectional sync', async () => {
-      (AsyncStorage.getItem as jest.Mock).mockResolvedValue('[]');
-      
-      (supabase.from as jest.Mock).mockReturnValue({
-        select: jest.fn().mockReturnValue({
-          eq: jest.fn().mockReturnValue({
-            gt: jest.fn().mockResolvedValue({ data: [], error: null }),
-          }),
-        }),
-        upsert: jest.fn().mockResolvedValue({ data: [], error: null }),
-      });
-
-      const result = await syncService.fullSync(mockUserId);
-
-      expect(result.success).toBe(true);
-    });
-  });
-
-  describe('enableAutoSync', () => {
-    it('should enable automatic sync', async () => {
-      await syncService.enableAutoSync(mockUserId, 5 * 60 * 1000); // 5 minutes
-
-      expect(syncService.isAutoSyncEnabled()).toBe(true);
-    });
-  });
-
-  describe('disableAutoSync', () => {
-    it('should disable automatic sync', async () => {
-      await syncService.enableAutoSync(mockUserId, 5 * 60 * 1000);
-      await syncService.disableAutoSync();
-
-      expect(syncService.isAutoSyncEnabled()).toBe(false);
+      expect(fromSpy).toHaveBeenCalledWith('transcriptions');
     });
   });
 });


### PR DESCRIPTION
Addresses **Category A** of #7 — the 46 failing service tests.

These were aspirational tests written against APIs the services never had. Rewrote each to test the **real shipped API** with meaningful behavioral assertions (no weakening, no skips, no tautologies).

## Result (verified independently)
- Mobile tests: **46 failed / 1782 passed → 0 failed / 1827 passed**
- 91 assertions across 58 tests, 5 suites now green
- **No production code changed** — the services were correct; the tests were wrong
- Zero regressions

## Files
syncService, supabaseService, AIMLService, AudioRecorder, offlineStorageService test suites.

## Still open (#7 Category B — separate, larger effort)
81 screen/integration suites still fail to LOAD (0 tests counted). Confirmed by experiment: mocking `@stripe/stripe-react-native` makes them load, but their assertions then fail because the tests expect testIDs/structure the real screens don't render — so this is a **per-screen test-rewrite effort across ~77 screens**, plus 3 tests needing `expo-device`/firebase deps + API rewrites, and 1 empty file. Recommend scoping as its own effort.